### PR TITLE
Bumped development version to 3.10.0-SNAPSHOT.

### DIFF
--- a/features/eclipse-jetty/feature.xml
+++ b/features/eclipse-jetty/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="net.sourceforge.eclipsejetty.feature"
       label="Eclipse Jetty Feature"
-      version="3.9.0.qualifier"
+      version="3.10.0.qualifier"
       provider-name="Christian Köberl">
 
    <description url="http://eclipse-jetty.github.io/">
@@ -35,7 +35,7 @@ limitations under the License.
          id="net.sourceforge.eclipsejetty.launcher"
          download-size="25"
          install-size="25"
-         version="3.9.0.qualifier"
+         version="3.10.0.qualifier"
          unpack="false"/>
 
 </feature>

--- a/features/eclipse-jetty/pom.xml
+++ b/features/eclipse-jetty/pom.xml
@@ -1,14 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
-	xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	
 	<modelVersion>4.0.0</modelVersion>
 	
 	<parent>
 		<groupId>net.sourceforge.eclipsejetty</groupId>
 		<artifactId>parent</artifactId>
-		<version>3.9.0-SNAPSHOT</version>
+		<version>3.10.0-SNAPSHOT</version>
 		<relativePath>../..</relativePath>
 	</parent>
 	

--- a/plugins/eclipse-jetty-launcher/META-INF/MANIFEST.MF
+++ b/plugins/eclipse-jetty-launcher/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse Jetty Launcher Plugin
 Bundle-SymbolicName: net.sourceforge.eclipsejetty.launcher;singleton:=true
-Bundle-Version: 3.9.0.qualifier
+Bundle-Version: 3.10.0.qualifier
 Bundle-Activator: net.sourceforge.eclipsejetty.JettyPlugin
 Bundle-Vendor: Christian Köberl, Manfred Hantschel
 Require-Bundle: org.eclipse.ui,

--- a/plugins/eclipse-jetty-launcher/pom.xml
+++ b/plugins/eclipse-jetty-launcher/pom.xml
@@ -1,12 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
-	xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>net.sourceforge.eclipsejetty</groupId>
 		<artifactId>parent</artifactId>
-		<version>3.9.0-SNAPSHOT</version>
+		<version>3.10.0-SNAPSHOT</version>
 		<relativePath>../..</relativePath>
 	</parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -1,11 +1,10 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>net.sourceforge.eclipsejetty</groupId>
 	<artifactId>parent</artifactId>
 	<packaging>pom</packaging>
 	<name>Eclipse Jetty Integration</name>
-	<version>3.9.0-SNAPSHOT</version>
+	<version>3.10.0-SNAPSHOT</version>
 	<description>Provides integration for Jetty server as launch configurations in Eclipse.</description>
 	<url>http://eclipse-jetty.github.io/</url>
 	<inceptionYear>2009</inceptionYear>
@@ -103,7 +102,7 @@
 										</goals>
 									</pluginExecutionFilter>
 									<action>
-										<ignore></ignore>
+										<ignore />
 									</action>
 								</pluginExecution>
 							</pluginExecutions>

--- a/site/category.xml
+++ b/site/category.xml
@@ -3,7 +3,7 @@
    <description url="http://eclipse-jetty.github.io/update/">
       Eclipse Jetty Integration
    </description>
-   <feature url="features/net.sourceforge.eclipsejetty.feature_3.9.0.qualifier.jar" id="net.sourceforge.eclipsejetty.feature" version="3.9.0.qualifier">
+   <feature url="features/net.sourceforge.eclipsejetty.feature_3.10.0.qualifier.jar" id="net.sourceforge.eclipsejetty.feature" version="3.10.0.qualifier">
       <category name="eclipsejetty"/>
    </feature>
    <category-def name="eclipsejetty" label="Eclipse Jetty Integration"/>

--- a/site/pom.xml
+++ b/site/pom.xml
@@ -1,12 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
-	xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>net.sourceforge.eclipsejetty</groupId>
 		<artifactId>parent</artifactId>
-		<version>3.9.0-SNAPSHOT</version>
+		<version>3.10.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>eclipse-jetty-site</artifactId>
 	<packaging>eclipse-repository</packaging>

--- a/starters/common/pom.xml
+++ b/starters/common/pom.xml
@@ -1,12 +1,11 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
 	<modelVersion>4.0.0</modelVersion>
 
 	<parent>
 		<groupId>net.sourceforge.eclipsejetty</groupId>
 		<artifactId>eclipse-jetty-starters</artifactId>
-		<version>3.9.0-SNAPSHOT</version>
+		<version>3.10.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>eclipse-jetty-starters-common</artifactId>

--- a/starters/console/pom.xml
+++ b/starters/console/pom.xml
@@ -1,12 +1,11 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
 	<modelVersion>4.0.0</modelVersion>
 
 	<parent>
 		<groupId>net.sourceforge.eclipsejetty</groupId>
 		<artifactId>eclipse-jetty-starters</artifactId>
-		<version>3.9.0-SNAPSHOT</version>
+		<version>3.10.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>eclipse-jetty-starters-console</artifactId>

--- a/starters/embedded/pom.xml
+++ b/starters/embedded/pom.xml
@@ -1,12 +1,11 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
 	<modelVersion>4.0.0</modelVersion>
 
 	<parent>
 		<groupId>net.sourceforge.eclipsejetty</groupId>
 		<artifactId>eclipse-jetty-starters</artifactId>
-		<version>3.9.0-SNAPSHOT</version>
+		<version>3.10.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>eclipse-jetty-starters-embedded</artifactId>

--- a/starters/jetty6/pom.xml
+++ b/starters/jetty6/pom.xml
@@ -1,12 +1,11 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
 	<modelVersion>4.0.0</modelVersion>
 
 	<parent>
 		<groupId>net.sourceforge.eclipsejetty</groupId>
 		<artifactId>eclipse-jetty-starters</artifactId>
-		<version>3.9.0-SNAPSHOT</version>
+		<version>3.10.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>eclipse-jetty-starters-jetty6</artifactId>

--- a/starters/jetty7/pom.xml
+++ b/starters/jetty7/pom.xml
@@ -1,12 +1,11 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
 	<modelVersion>4.0.0</modelVersion>
 
 	<parent>
 		<groupId>net.sourceforge.eclipsejetty</groupId>
 		<artifactId>eclipse-jetty-starters</artifactId>
-		<version>3.9.0-SNAPSHOT</version>
+		<version>3.10.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>eclipse-jetty-starters-jetty7</artifactId>

--- a/starters/jetty8/pom.xml
+++ b/starters/jetty8/pom.xml
@@ -1,12 +1,11 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
 	<modelVersion>4.0.0</modelVersion>
 
 	<parent>
 		<groupId>net.sourceforge.eclipsejetty</groupId>
 		<artifactId>eclipse-jetty-starters</artifactId>
-		<version>3.9.0-SNAPSHOT</version>
+		<version>3.10.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>eclipse-jetty-starters-jetty8</artifactId>

--- a/starters/jetty9/pom.xml
+++ b/starters/jetty9/pom.xml
@@ -1,12 +1,11 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
 	<modelVersion>4.0.0</modelVersion>
 
 	<parent>
 		<groupId>net.sourceforge.eclipsejetty</groupId>
 		<artifactId>eclipse-jetty-starters</artifactId>
-		<version>3.9.0-SNAPSHOT</version>
+		<version>3.10.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>eclipse-jetty-starters-jetty9</artifactId>

--- a/starters/pom.xml
+++ b/starters/pom.xml
@@ -1,12 +1,11 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
 	<modelVersion>4.0.0</modelVersion>
 
 	<parent>
 		<groupId>net.sourceforge.eclipsejetty</groupId>
 		<artifactId>parent</artifactId>
-		<version>3.9.0-SNAPSHOT</version>
+		<version>3.10.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>eclipse-jetty-starters</artifactId>

--- a/starters/util/pom.xml
+++ b/starters/util/pom.xml
@@ -1,12 +1,11 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
 	<modelVersion>4.0.0</modelVersion>
 
 	<parent>
 		<groupId>net.sourceforge.eclipsejetty</groupId>
 		<artifactId>eclipse-jetty-starters</artifactId>
-		<version>3.9.0-SNAPSHOT</version>
+		<version>3.10.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>eclipse-jetty-starters-util</artifactId>


### PR DESCRIPTION
Ran:

`mvn -Dline.separator=$'\r\n' -o release:update-versions -DautoVersionSubmodules=true -DdevelopmentVersion=3.10.0-SNAPSHOT`

... followed by some `dos2unix` to fix inconsistent EOLs (need to fix that).

Manual change for a couple of OSGi props.