### PR TITLE
Upgrade Jetty 9.3 to version 9.3.25.v20180904

### DIFF
--- a/starters/pom.xml
+++ b/starters/pom.xml
@@ -18,7 +18,7 @@
         <version.jetty6>6.1.26</version.jetty6>
         <version.jetty7>7.6.12.v20130726</version.jetty7>
         <version.jetty8>8.1.14.v20131031</version.jetty8>
-        <version.jetty9>9.3.12.v20160915</version.jetty9>
+        <version.jetty9>9.3.25.v20180904</version.jetty9>
     </properties>
 
     <modules>


### PR DESCRIPTION
version 9.3.25.v20180904 supports ASM version 6 (https://github.com/eclipse/jetty.project/issues/1213)