### PR TITLE
add support for jetty 9.4.x

### DIFF
--- a/plugins/eclipse-jetty-launcher/src/main/java/net/sourceforge/eclipsejetty/jetty/JettyVersion.java
+++ b/plugins/eclipse-jetty-launcher/src/main/java/net/sourceforge/eclipsejetty/jetty/JettyVersion.java
@@ -331,9 +331,13 @@ public class JettyVersion
                 {
                     return JettyVersionType.JETTY_9;
                 }
-                else
+                else if (minorVersion.intValue() < 4)
                 {
                     return JettyVersionType.JETTY_9_3;
+                }
+                else
+                {
+                    return JettyVersionType.JETTY_9_4;
                 }
             }
             default:

--- a/plugins/eclipse-jetty-launcher/src/main/java/net/sourceforge/eclipsejetty/jetty/JettyVersionType.java
+++ b/plugins/eclipse-jetty-launcher/src/main/java/net/sourceforge/eclipsejetty/jetty/JettyVersionType.java
@@ -12,8 +12,6 @@
 package net.sourceforge.eclipsejetty.jetty;
 
 import net.sourceforge.eclipsejetty.jetty.embedded.JettyEmbeddedLibStrategy;
-import net.sourceforge.eclipsejetty.jetty.embedded.JettyEmbeddedServerConfiguration;
-import net.sourceforge.eclipsejetty.jetty.embedded.JettyEmbeddedWebDefaults;
 import net.sourceforge.eclipsejetty.jetty6.Jetty6LibStrategy;
 import net.sourceforge.eclipsejetty.jetty6.Jetty6ServerConfiguration;
 import net.sourceforge.eclipsejetty.jetty6.Jetty6WebDefaults;
@@ -23,8 +21,9 @@ import net.sourceforge.eclipsejetty.jetty7.Jetty7WebDefaults;
 import net.sourceforge.eclipsejetty.jetty8.Jetty8LibStrategy;
 import net.sourceforge.eclipsejetty.jetty8.Jetty8ServerConfiguration;
 import net.sourceforge.eclipsejetty.jetty8.Jetty8WebDefaults;
-import net.sourceforge.eclipsejetty.jetty9.Jetty9LibStrategy;
 import net.sourceforge.eclipsejetty.jetty9.Jetty93LibStrategy;
+import net.sourceforge.eclipsejetty.jetty9.Jetty94LibStrategy;
+import net.sourceforge.eclipsejetty.jetty9.Jetty9LibStrategy;
 import net.sourceforge.eclipsejetty.jetty9.Jetty9ServerConfiguration;
 import net.sourceforge.eclipsejetty.jetty9.Jetty9WebDefaults;
 
@@ -67,7 +66,10 @@ public enum JettyVersionType
         Jetty9ServerConfiguration.class, new Jetty9LibStrategy(), Jetty9WebDefaults.class),
 
     JETTY_9_3("net.sourceforge.eclipsejetty.starter.jetty9.Jetty9LauncherMain", "lib/eclipse-jetty-starters-jetty9.jar",
-            Jetty9ServerConfiguration.class, new Jetty93LibStrategy(), Jetty9WebDefaults.class);
+            Jetty9ServerConfiguration.class, new Jetty93LibStrategy(), Jetty9WebDefaults.class),
+    
+    JETTY_9_4("net.sourceforge.eclipsejetty.starter.jetty9.Jetty9LauncherMain", "lib/eclipse-jetty-starters-jetty9.jar",
+            Jetty9ServerConfiguration.class, new Jetty94LibStrategy(), Jetty9WebDefaults.class);
 	
     private final String mainClass;
     private final String jar;

--- a/plugins/eclipse-jetty-launcher/src/main/java/net/sourceforge/eclipsejetty/jetty9/Jetty94LibStrategy.java
+++ b/plugins/eclipse-jetty-launcher/src/main/java/net/sourceforge/eclipsejetty/jetty9/Jetty94LibStrategy.java
@@ -16,18 +16,28 @@ import java.util.Collection;
 import net.sourceforge.eclipsejetty.jetty8.Jetty8LibStrategy;
 
 /**
- * Resolve libs for Jetty 9
+ * Resolve libs for Jetty 9.4.x
  * 
  * @author Christian K&ouml;berl
  * @author Manfred Hantschel
+ * @author Andreas Stubenrauch
  */
-public class Jetty9LibStrategy extends Jetty8LibStrategy
+public class Jetty94LibStrategy extends Jetty8LibStrategy
 {
     @Override
     protected void addServerDependencies(Collection<String> dependencies)
     {
-        dependencies.add(".*\\/lib\\/jetty-.*\\.jar");
         dependencies.add(".*/servlet-api-.*\\.jar");
+        dependencies.add(".*/jetty-schemas-.*\\.jar");
+        dependencies.add(".*/jetty-http-.*\\.jar");
+        dependencies.add(".*/jetty-server-.*\\.jar");
+        dependencies.add(".*/jetty-xml-.*\\.jar");
+        dependencies.add(".*/jetty-util-.*\\.jar");
+        dependencies.add(".*/jetty-io-.*\\.jar");
+        dependencies.add(".*/jetty-security-.*\\.jar");
+        dependencies.add(".*/jetty-servlet-.*\\.jar");
+        dependencies.add(".*/jetty-webapp-.*\\.jar");
+        dependencies.add(".*/jetty-deploy-.*\\.jar");
     }
 
     @Override
@@ -40,23 +50,29 @@ public class Jetty9LibStrategy extends Jetty8LibStrategy
     @Override
     protected void addJMXDependencies(Collection<String> dependencies)
     {
+        dependencies.add(".*/jetty-jmx-.*\\.jar");
     }
 
     @Override
     protected void addJNDIDependencies(Collection<String> dependencies)
     {
-        dependencies.add(".*/jndi/.*\\.jar");
+        dependencies.add(".*/mail/.*\\.jar");
+        dependencies.add(".*/jetty-jndi-.*\\.jar");
+        dependencies.add(".*/transactions/.*\\.jar");
+        dependencies.add(".*/jetty-plus-.*\\.jar");
     }
 
     @Override
     protected void addAnnotationsDependencies(Collection<String> dependencies)
     {
+        dependencies.add(".*/jetty-annotations-.*\\.jar");
         dependencies.add(".*/annotations/.*\\.jar");
     }
 
     @Override
     protected void addWebsocketSupport(Collection<String> dependencies)
     {
+        dependencies.add(".*/jetty-client-.*\\.jar");
         dependencies.add(".*/websocket/.*\\.jar");
     }
 }


### PR DESCRIPTION
Hi,
in jetty 9.4.x the way the classpath is assembled changed again a bit. This is a quick hack to add support for jetty versions 9.4.x