### PR TITLE
Adding Maven dependencies in JDK9+ projects to classpath

### DIFF
--- a/plugins/eclipse-jetty-launcher/pom.xml
+++ b/plugins/eclipse-jetty-launcher/pom.xml
@@ -80,8 +80,8 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>1.5</source>
-                    <target>1.5</target>
+                    <source>1.6</source>
+                    <target>1.6</target>
                 </configuration>
             </plugin>
 

--- a/plugins/eclipse-jetty-launcher/src/main/java/net/sourceforge/eclipsejetty/launch/util/JettyLaunchConfigurationDelegate.java
+++ b/plugins/eclipse-jetty-launcher/src/main/java/net/sourceforge/eclipsejetty/launch/util/JettyLaunchConfigurationDelegate.java
@@ -340,7 +340,7 @@ public class JettyLaunchConfigurationDelegate extends JavaLaunchDelegate
             scopedClasspathEntries.add(Dependency.create(mavenScopeCollection, entry));
         }
 
-        result = Collections.unmodifiableCollection(userClasses().match(scopedClasspathEntries));
+        result = Collections.unmodifiableCollection(or(userClasses(), classPath()).match(scopedClasspathEntries));
 
         putCached("OriginalClasspathEntries", adapter, result); //$NON-NLS-1$
 
@@ -678,7 +678,7 @@ public class JettyLaunchConfigurationDelegate extends JavaLaunchDelegate
     private DependencyMatcher createWebappClasspathMatcher(JettyLaunchConfigurationAdapter adapter)
         throws CoreException
     {
-        DependencyMatcher vmClasspathMatcher = userClasses();
+        DependencyMatcher vmClasspathMatcher = or(userClasses(), classPath());
 
         if (adapter.isGenericIdsSupported())
         {

--- a/plugins/eclipse-jetty-launcher/src/main/java/net/sourceforge/eclipsejetty/util/DependencyMatcher.java
+++ b/plugins/eclipse-jetty-launcher/src/main/java/net/sourceforge/eclipsejetty/util/DependencyMatcher.java
@@ -191,6 +191,11 @@ public abstract class DependencyMatcher
         return withClasspathProperty(IRuntimeClasspathEntry.USER_CLASSES);
     }
 
+    public static DependencyMatcher classPath()
+    {
+        return withClasspathProperty(IRuntimeClasspathEntry.CLASS_PATH);
+    }
+
     /**
      * Matches only those entries with the specified classpath property: BOOTSTRAP_CLASSES, STANDARD_CLASSES,
      * USER_CLASSES.

--- a/pom.xml
+++ b/pom.xml
@@ -161,8 +161,8 @@
 
 	<repositories>
 		<repository>
-			<id>eclipse-indigo</id>
-			<url>http://download.eclipse.org/releases/indigo</url>
+			<id>eclipse-oxygen</id>
+			<url>http://download.eclipse.org/releases/oxygen</url>
 			<layout>p2</layout>
 		</repository>
 	</repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -73,8 +73,8 @@
 					<artifactId>maven-compiler-plugin</artifactId>
 					<version>3.1</version>
 					<configuration>
-						<source>1.5</source>
-						<target>1.5</target>
+						<source>1.6</source>
+						<target>1.6</target>
 					</configuration>
 				</plugin>
 

--- a/samples/quickstart/pom.xml
+++ b/samples/quickstart/pom.xml
@@ -110,8 +110,8 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>2.3.2</version>
 				<configuration>
-					<source>1.5</source>
-					<target>1.5</target>
+					<source>1.6</source>
+					<target>1.6</target>
 					<optimize>true</optimize>
 				</configuration>
 			</plugin>

--- a/starters/common/pom.xml
+++ b/starters/common/pom.xml
@@ -33,8 +33,8 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
 				<configuration>
-					<source>1.5</source>
-					<target>1.5</target>
+					<source>1.6</source>
+					<target>1.6</target>
 				</configuration>
 			</plugin>
 		</plugins>

--- a/starters/console/pom.xml
+++ b/starters/console/pom.xml
@@ -26,8 +26,8 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
 				<configuration>
-					<source>1.5</source>
-					<target>1.5</target>
+					<source>1.6</source>
+					<target>1.6</target>
 				</configuration>
 			</plugin>
 		</plugins>

--- a/starters/jetty6/pom.xml
+++ b/starters/jetty6/pom.xml
@@ -34,8 +34,8 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
 				<configuration>
-					<source>1.5</source>
-					<target>1.5</target>
+					<source>1.6</source>
+					<target>1.6</target>
 				</configuration>
 			</plugin>
 		</plugins>

--- a/starters/jetty7/pom.xml
+++ b/starters/jetty7/pom.xml
@@ -48,8 +48,8 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
 				<configuration>
-					<source>1.5</source>
-					<target>1.5</target>
+					<source>1.6</source>
+					<target>1.6</target>
 				</configuration>
 			</plugin>
 		</plugins>

--- a/starters/util/pom.xml
+++ b/starters/util/pom.xml
@@ -18,8 +18,8 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
 				<configuration>
-					<source>1.5</source>
-					<target>1.5</target>
+					<source>1.6</source>
+					<target>1.6</target>
 				</configuration>
 			</plugin>
 		</plugins>


### PR DESCRIPTION
Adding Maven dependencies in JDK9+ projects to classpath for displaying dependencies in launch configuration and including them when launching Jetty.

This required org.eclipse.jdt.launching 3.10 or above as the `org.eclipse.jdt.launching.IRuntimeClasspathEntry.CLASS_PATH` is not available in previous versions. To get this dependency, the p2 repository had to be upgraded from indigo to oxygen.

Fixes #48

