### PR TITLE
Fix Jetty9ServerConfiguration.buildAnnotations #51

### DIFF
--- a/plugins/eclipse-jetty-launcher/src/main/java/net/sourceforge/eclipsejetty/jetty9/Jetty9ServerConfiguration.java
+++ b/plugins/eclipse-jetty-launcher/src/main/java/net/sourceforge/eclipsejetty/jetty9/Jetty9ServerConfiguration.java
@@ -289,7 +289,7 @@ public class Jetty9ServerConfiguration extends Jetty8ServerConfiguration
             builder.argRef("Server");
             builder.beginCall("addBefore");
             {
-                builder.arg("addBefore", "org.eclipse.jetty.webapp.JettyWebXmlConfiguration");
+                builder.arg("beforeClass", "org.eclipse.jetty.webapp.JettyWebXmlConfiguration");
                 builder.argArray("org.eclipse.jetty.annotations.AnnotationConfiguration");
             }
             builder.end();


### PR DESCRIPTION
Jetty project changed xml configuration parsing in 9.4.27.
https://github.com/eclipse/jetty.project/commit/353dc9bf08864c8cfd4fbf9623b0ddc88de3aaef

The way xml parsing is done now does not allow invalid argument name anymore.
From our side, `Jetty9ServerConfiguration.buildAnnotations` was using `addBefore` instead of `beforeClass` since the beggining of jetty 9 support.

See `org.eclipse.jetty.webapp.Configuration$ClassList.addBefore`

```java
public void addBefore(@Name("beforeClass") String beforeClass,@Name("configClass")String... configClass)
```

I corrected the arg name, and tested against older version of jetty (older than 9.4.27), it still works as expected